### PR TITLE
feat: run model using ollama client inside container, reduce reliance on os.exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ go install github.com/sammcj/gollama@latest
 Or for bleeding edge:
 
 ```shell
-go install github.com/sammcj/gollama@main
+go install github.com/sammcj/gollama@HEAD
 ```
 
 From Github:
@@ -78,7 +78,7 @@ gollama
 
 - `Space`: Select
 - `Enter`: Run model (Ollama run)
-- `i`: Inspect model **Work in progress**
+- `i`: Inspect model
 - `t`: Top (show running models)
 - `D`: Delete model
 - `c`: Copy model
@@ -135,12 +135,15 @@ Example configuration:
   "log_level": "info",
   "log_file_path": "/Users/username/.config/gollama/gollama.log",
   "sort_order": "Size",
-  "strip_string": "my-private-registry.internal/"
+  "strip_string": "my-private-registry.internal/",
+  "editor": "",
+  "docker_container": ""
 }
 ```
 
-The strip string option can be used to remove a prefix from model names as they are displayed in the TUI.
-This can be useful if you have a common prefix such as a private registry that you want to remove for display purposes.
+- `strip_string` can be used to remove a prefix from model names as they are displayed in the TUI. This can be useful if you have a common prefix such as a private registry that you want to remove for display purposes.
+- `docker_container` - **experimental** - if set, gollama will attempt to perform any run operations inside the specified container.
+- `editor` - **experimental** - if set, gollama will use this editor to open the Modelfile for editing.
 
 ## Installation and build from source
 

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	LastSortSelection string   `json:"-"`            // Temporary field to hold the last sort selection
 	StripString       string   `json:"strip_string"` // Optional string to strip from model names in the TUI (e.g. a private registry URL)
 	Editor            string   `json:"editor"`
+	DockerContainer   string   `json:"docker_container"` // Optionally specify a docker container to run the ollama commands in
 }
 
 var defaultConfig = Config{
@@ -35,6 +36,7 @@ var defaultConfig = Config{
 	SortOrder:         "modified", // Default sort order
 	StripString:       "",
 	Editor:            "vim",
+	DockerContainer:   "",
 }
 
 func LoadConfig() (Config, error) {


### PR DESCRIPTION
- Experimental support for running the Ollama run command inside a container (note this can also be achieved by either building gollama into your Ollama container image, or simply by mounting gollama at container runtime). #20 
- Swap out some os.execs to native API calls.