### PR TITLE
feat: add shorthand 'l' for the -h / --host parameter to use localhost:11434, and default to get the vram estimation model from GOLLAMA_DEFAULT_MODEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Inspect (`i`)
 - `-no-cleanup`: Don't cleanup broken symlinks
 - `-u`: Unload all running models
 - `-v`: Print the version and exit
+- `-h`, or `--host`: Specify the host for the Ollama API, if you provide `l` as the host it will automatically use `http://localhost:11434`
 - `--vram`: Estimate vRAM usage for an existing (pulled) Ollama model name (e.g. `llama3.1:8b-instruct-q6_K`) huggingface model ID (e.g. `NousResearch/Hermes-2-Theta-Llama-3-8B`) **new**
   - `--fits`: Available memory in GB for context calculation (e.g. `6` for 6GB)
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Inspect (`i`)
 - `-u`: Unload all running models
 - `-v`: Print the version and exit
 - `-h`, or `--host`: Specify the host for the Ollama API, if you provide `l` as the host it will automatically use `http://localhost:11434`
-- `--vram`: Estimate vRAM usage for an existing (pulled) Ollama model name (e.g. `llama3.1:8b-instruct-q6_K`) huggingface model ID (e.g. `NousResearch/Hermes-2-Theta-Llama-3-8B`) **new**
+- `--vram`: Estimate vRAM usage for an existing (pulled) Ollama model name (e.g. `llama3.1:8b-instruct-q6_K`) huggingface model ID (e.g. `NousResearch/Hermes-2-Theta-Llama-3-8B`), you can also set `GOLLAMA_DEFAULT_MODEL` in your environment and provide `default` as the model name (I'll add a config option for this soon)
   - `--fits`: Available memory in GB for context calculation (e.g. `6` for 6GB)
 
 ##### Simple model listing

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ var Version string // Version is set by the build system
 
 func main() {
 	if Version == "" {
-		Version = "v1.20.5"
+		Version = "1.26.0"
 	}
 
 	cfg, err := config.LoadConfig()
@@ -131,7 +131,9 @@ func main() {
 
 	os.Setenv("EDITOR", cfg.Editor)
 
-	if *hostFlag != "" {
+  if *hostFlag == "l" {
+    *hostFlag = "http://localhost:11434"
+  } else if *hostFlag != "" {
 		cfg.OllamaAPIURL = *hostFlag
 	}
 
@@ -147,12 +149,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Handle vRAM estimation flags
+	// Handle --vram flag
 	if *vramFlag != "" {
-		logging.DebugLogger.Println("vRAM estimation flag detected")
-		if *vramFlag == "" {
-			fmt.Println("Error: Model ID or Ollama model name is required for vRAM estimation")
-			os.Exit(1)
+		modelName := *vramFlag
+		if modelName == "" {
+			modelName = os.Getenv("GOLLAMA_DEFAULT_MODEL")
+			if modelName == "" {
+				fmt.Println("Error: Model ID or Ollama model name is required for vRAM estimation. Please provide a --vram argument or set the GOLLAMA_DEFAULT_MODEL environment variable.")
+				os.Exit(1)
+			}
 		}
 
 		logging.DebugLogger.Println("Generating VRAM estimation table")
@@ -161,15 +166,15 @@ func main() {
 		var err error
 
 		// Check if the input is an Ollama model name (contains a colon)
-		if strings.Contains(*vramFlag, ":") {
-			ollamaModelInfo, err = vramestimator.FetchOllamaModelInfo(url.String(), *vramFlag)
+		if strings.Contains(modelName, ":") {
+			ollamaModelInfo, err = vramestimator.FetchOllamaModelInfo(cfg.OllamaAPIURL, modelName)
 			if err != nil {
 				fmt.Printf("Error fetching Ollama model info: %v\n", err)
 				os.Exit(1)
 			}
 		}
 
-		table, err := vramestimator.GenerateQuantTable(*vramFlag, "", fitsVRAM, ollamaModelInfo)
+		table, err := vramestimator.GenerateQuantTable(modelName, "", fitsVRAM, ollamaModelInfo)
 		if err != nil {
 			fmt.Printf("Error generating VRAM estimation table: %v\n", err)
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -119,8 +119,8 @@ func main() {
 	hostFlag := flag.String("h", "", "Override the config file to set the Ollama API host (e.g. http://localhost:11434)")
 	editFlag := flag.Bool("e", false, "Edit a model's modelfile")
 	// vRAM estimation flags
-	vramFlag := flag.String("vram", "", "Estimate vRAM usage - Model ID or Ollama model name")
 	flag.Float64Var(&fitsVRAM, "fits", 0, "Highlight quant sizes and context sizes that fit in this amount of vRAM (in GB)")
+	vramFlag := flag.String("vram", "", "Estimate vRAM usage - Model ID or Ollama model name")
 
 	flag.Parse()
 
@@ -152,7 +152,7 @@ func main() {
 	// Handle --vram flag
 	if *vramFlag != "" {
 		modelName := *vramFlag
-		if modelName == "" {
+		if modelName == "default" {
 			modelName = os.Getenv("GOLLAMA_DEFAULT_MODEL")
 			if modelName == "" {
 				fmt.Println("Error: Model ID or Ollama model name is required for vRAM estimation. Please provide a --vram argument or set the GOLLAMA_DEFAULT_MODEL environment variable.")


### PR DESCRIPTION
feat: add shorthand 'l' for the -h / --host parameter to use localhost:11434
feat: provide 'default' to --vram to get the vram estimation model from GOLLAMA_DEFAULT_MODEL