### PR TITLE
fix: vram estimates for new gguf metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Inspect (`i`)
 - `-H`: Shortcut for `-h http://localhost:11434` (connect to local Ollama API) **new**
 - `--vram`: Estimate vRAM usage for an existing (pulled) Ollama model name (e.g. `llama3.1:8b-instruct-q6_K`) huggingface model ID (e.g. `NousResearch/Hermes-2-Theta-Llama-3-8B`)
   - `--fits`: Available memory in GB for context calculation (e.g. `6` for 6GB)
+  - `--vram-to-nth`: Top context length to search for (e.g. `40k` or `40000`)
 
 ##### Simple model listing
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/ollama/ollama v0.3.10
+	github.com/ollama/ollama v0.3.11
 	github.com/rs/zerolog v1.33.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/spf13/viper v1.19.0
@@ -21,7 +21,7 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/charmbracelet/x/ansi v0.3.1 // indirect
+	github.com/charmbracelet/x/ansi v0.3.2 // indirect
 	github.com/charmbracelet/x/term v0.2.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v0.13.0 h1:4X3PPeoWEDCMvzDvGmTajSyYPcZM4+y8sCA/SsA3cjw=
 github.com/charmbracelet/lipgloss v0.13.0/go.mod h1:nw4zy0SBX/F/eAO1cWdcvy6qnkDUxr8Lw7dvFrAIbbY=
-github.com/charmbracelet/x/ansi v0.3.1 h1:CRO6lc/6HCx2/D6S/GZ87jDvRvk6GtPyFP+IljkNtqI=
-github.com/charmbracelet/x/ansi v0.3.1/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
+github.com/charmbracelet/x/ansi v0.3.2 h1:wsEwgAN+C9U06l9dCVMX0/L3x7ptvY1qmjMwyfE6USY=
+github.com/charmbracelet/x/ansi v0.3.2/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b h1:MnAMdlwSltxJyULnrYbkZpp4k58Co7Tah3ciKhSNo0Q=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.0 h1:cNB9Ot9q8I711MyZ7myUR5HFWL/lc3OpU8jZ4hwm0x0=
@@ -73,8 +73,8 @@ github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4
 github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/ollama/ollama v0.3.10 h1:fVOEBJjCGcWwrimipKWZwq0dBW39fMrYkJYMA81ghaE=
-github.com/ollama/ollama v0.3.10/go.mod h1:YrWoNkFnPOYsnDvsf/Ztb1wxU9/IXrNsQHqcxbY2r94=
+github.com/ollama/ollama v0.3.11 h1:Fs1B5WjXYUvr5bkMZZpUJfiqIAxrymujRidFABwMeV8=
+github.com/ollama/ollama v0.3.11/go.mod h1:YrWoNkFnPOYsnDvsf/Ztb1wxU9/IXrNsQHqcxbY2r94=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ var Version string // Version is set by the build system
 
 func main() {
 	if Version == "" {
-		Version = "1.27.6"
+		Version = "1.27.7"
 	}
 
 	cfg, err := config.LoadConfig()

--- a/main.go
+++ b/main.go
@@ -122,6 +122,7 @@ func main() {
 	// vRAM estimation flags
 	flag.Float64Var(&fitsVRAM, "fits", 0, "Highlight quant sizes and context sizes that fit in this amount of vRAM (in GB)")
 	vramFlag := flag.String("vram", "", "Estimate vRAM usage - Model ID or Ollama model name")
+	topContextFlag := flag.String("vram-to-nth", "65536", "Top context length to search for (e.g., 65536, 32k, 2m)")
 
 	flag.Parse()
 
@@ -175,7 +176,14 @@ func main() {
 			}
 		}
 
-		table, err := vramestimator.GenerateQuantTable(modelName, os.Getenv("HUGGINGFACE_TOKEN"), fitsVRAM, ollamaModelInfo)
+		// Parse the top context size
+		topContext, err := parseContextSize(*topContextFlag)
+		if err != nil {
+			fmt.Printf("Error parsing top context size: %v\n", err)
+			os.Exit(1)
+		}
+
+		table, err := vramestimator.GenerateQuantTable(modelName, os.Getenv("HUGGINGFACE_TOKEN"), fitsVRAM, ollamaModelInfo, topContext)
 		if err != nil {
 			fmt.Printf("Error generating VRAM estimation table: %v\n", err)
 			os.Exit(1)

--- a/operations.go
+++ b/operations.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -760,4 +761,24 @@ func editModelfile(client *api.Client, modelName string) (string, error) {
 
 func isLocalhost(url string) bool {
 	return strings.Contains(url, "localhost") || strings.Contains(url, "127.0.0.1")
+}
+
+func parseContextSize(input string) (int, error) {
+	input = strings.ToLower(input)
+	multiplier := 1
+
+	if strings.HasSuffix(input, "k") {
+		multiplier = 1024
+		input = strings.TrimSuffix(input, "k")
+	} else if strings.HasSuffix(input, "m") {
+		multiplier = 1024 * 1024
+		input = strings.TrimSuffix(input, "m")
+	}
+
+	value, err := strconv.Atoi(input)
+	if err != nil {
+		return 0, fmt.Errorf("invalid context size: %s", input)
+	}
+
+	return value * multiplier, nil
 }

--- a/vramestimator/vramestimator.go
+++ b/vramestimator/vramestimator.go
@@ -173,58 +173,58 @@ func GetAvailableMemory() (float64, error) {
 }
 
 type OllamaModelInfo struct {
-    Details struct {
-        ParameterSize     string   `json:"parameter_size"`
-        QuantizationLevel string   `json:"quantization_level"`
-        Family            string   `json:"family"`
-        Families          []string `json:"families"`
-    } `json:"details"`
-    ModelInfo map[string]interface{} `json:"model_info"`
+	Details struct {
+		ParameterSize     string   `json:"parameter_size"`
+		QuantizationLevel string   `json:"quantization_level"`
+		Family            string   `json:"family"`
+		Families          []string `json:"families"`
+	} `json:"details"`
+	ModelInfo map[string]interface{} `json:"model_info"`
 }
 
 func extractModelInfo(info map[string]interface{}, key string) (float64, bool) {
-    for k, v := range info {
-        if strings.HasSuffix(k, key) {
-            switch val := v.(type) {
-            case float64:
-                return val, true
-            case int64:
-                return float64(val), true
-            case int:
-                return float64(val), true
-            }
-        }
-    }
-    return 0, false
+	for k, v := range info {
+		if strings.HasSuffix(k, key) {
+			switch val := v.(type) {
+			case float64:
+				return val, true
+			case int64:
+				return float64(val), true
+			case int:
+				return float64(val), true
+			}
+		}
+	}
+	return 0, false
 }
 
 func FetchOllamaModelInfo(apiURL, modelName string) (*OllamaModelInfo, error) {
-    url := fmt.Sprintf("%s/api/show", apiURL)
-    payload := []byte(fmt.Sprintf(`{"name": "%s"}`, modelName))
+	url := fmt.Sprintf("%s/api/show", apiURL)
+	payload := []byte(fmt.Sprintf(`{"name": "%s"}`, modelName))
 
-    resp, err := http.Post(url, "application/json", bytes.NewBuffer(payload))
-    if err != nil {
-        return nil, fmt.Errorf("error making request to Ollama API: %v", err)
-    }
-    defer resp.Body.Close()
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, fmt.Errorf("error making request to Ollama API: %v", err)
+	}
+	defer resp.Body.Close()
 
-    if resp.StatusCode != http.StatusOK {
-        return nil, fmt.Errorf("ollama API returned non-OK status: %d", resp.StatusCode)
-    }
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ollama API returned non-OK status: %d", resp.StatusCode)
+	}
 
-    body, err := io.ReadAll(resp.Body)
-    if err != nil {
-        return nil, fmt.Errorf("error reading Ollama API response: %v", err)
-    }
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading Ollama API response: %v", err)
+	}
 
-    logging.DebugLogger.Printf("Raw Ollama API response: %s", string(body))
+	logging.DebugLogger.Printf("Raw Ollama API response: %s", string(body))
 
-    var modelInfo OllamaModelInfo
-    if err := json.Unmarshal(body, &modelInfo); err != nil {
-        return nil, fmt.Errorf("error decoding Ollama API response: %v", err)
-    }
+	var modelInfo OllamaModelInfo
+	if err := json.Unmarshal(body, &modelInfo); err != nil {
+		return nil, fmt.Errorf("error decoding Ollama API response: %v", err)
+	}
 
-    return &modelInfo, nil
+	return &modelInfo, nil
 }
 
 func EstimateVRAM(modelIdentifier, apiURL string, fitsVRAM float64) error {
@@ -240,7 +240,7 @@ func EstimateVRAM(modelIdentifier, apiURL string, fitsVRAM float64) error {
 	}
 
 	// Generate the quantization table
-	table, err := GenerateQuantTable(modelIdentifier, "", fitsVRAM, ollamaModelInfo)
+	table, err := GenerateQuantTable(modelIdentifier, "", fitsVRAM, ollamaModelInfo, 65536)
 	if err != nil {
 		return fmt.Errorf("error generating quantization table: %v", err)
 	}
@@ -451,141 +451,145 @@ func GetBPWValues(bpw float64, kvCacheQuant KVCacheQuantisation) BPWValues {
 
 // CalculateVRAM calculates the VRAM usage for a given model and configuration
 func CalculateVRAM(modelID string, bpw float64, context int, kvCacheQuant KVCacheQuantisation, accessToken string, ollamaModelInfo *OllamaModelInfo) (float64, error) {
-    logging.DebugLogger.Println("Calculating VRAM usage...")
+	logging.DebugLogger.Println("Calculating VRAM usage...")
 
-    var config ModelConfig
-    var err error
+	var config ModelConfig
+	var err error
 
-    if ollamaModelInfo != nil {
-        // Use Ollama model information
-        paramCount, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "parameter_count")
-        contextLength, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "context_length")
-        blockCount, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "block_count")
-        embeddingLength, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "embedding_length")
-        headCountKV, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "attention.head_count_kv")
-        headCount, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "attention.head_count")
-        feedForwardLength, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "feed_forward_length")
-        vocabSize, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "vocab_size")
+	if ollamaModelInfo != nil {
+		// Use Ollama model information
+		paramCount, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "parameter_count")
+		contextLength, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "context_length")
+		blockCount, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "block_count")
+		embeddingLength, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "embedding_length")
+		headCountKV, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "attention.head_count_kv")
+		headCount, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "attention.head_count")
+		feedForwardLength, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "feed_forward_length")
+		vocabSize, _ := extractModelInfo(ollamaModelInfo.ModelInfo, "vocab_size")
 
-        config = ModelConfig{
-            NumParams:             paramCount / 1e9, // Convert to billions
-            MaxPositionEmbeddings: int(contextLength),
-            NumHiddenLayers:       int(blockCount),
-            HiddenSize:            int(embeddingLength),
-            NumKeyValueHeads:      int(headCountKV),
-            NumAttentionHeads:     int(headCount),
-            IntermediateSize:      int(feedForwardLength),
-            VocabSize:             int(vocabSize),
-        }
+		config = ModelConfig{
+			NumParams:             paramCount / 1e9, // Convert to billions
+			MaxPositionEmbeddings: int(contextLength),
+			NumHiddenLayers:       int(blockCount),
+			HiddenSize:            int(embeddingLength),
+			NumKeyValueHeads:      int(headCountKV),
+			NumAttentionHeads:     int(headCount),
+			IntermediateSize:      int(feedForwardLength),
+			VocabSize:             int(vocabSize),
+		}
 
-        // Estimate missing values
-        if config.HiddenSize == 0 {
-            config.HiddenSize = int(math.Sqrt(paramCount / 1000))
-        }
-        if config.NumHiddenLayers == 0 {
-            config.NumHiddenLayers = int(math.Round(config.NumParams * 1e9 / (12 * float64(config.HiddenSize) * float64(config.HiddenSize))))
-        }
-        if config.NumAttentionHeads == 0 {
-            config.NumAttentionHeads = config.HiddenSize / 64 // Assuming 64 dimension per head
-        }
-        if config.NumKeyValueHeads == 0 {
-            config.NumKeyValueHeads = config.NumAttentionHeads
-        }
-        if config.IntermediateSize == 0 {
-            config.IntermediateSize = 4 * config.HiddenSize
-        }
-        if config.VocabSize == 0 {
-            config.VocabSize = 32000 // A common default value
-        }
+		// Estimate missing values
+		if config.HiddenSize == 0 {
+			config.HiddenSize = int(math.Sqrt(paramCount / 1000))
+		}
+		if config.NumHiddenLayers == 0 {
+			config.NumHiddenLayers = int(math.Round(config.NumParams * 1e9 / (12 * float64(config.HiddenSize) * float64(config.HiddenSize))))
+		}
+		if config.NumAttentionHeads == 0 {
+			config.NumAttentionHeads = config.HiddenSize / 64 // Assuming 64 dimension per head
+		}
+		if config.NumKeyValueHeads == 0 {
+			config.NumKeyValueHeads = config.NumAttentionHeads
+		}
+		if config.IntermediateSize == 0 {
+			config.IntermediateSize = 4 * config.HiddenSize
+		}
+		if config.VocabSize == 0 {
+			config.VocabSize = 32000 // A common default value
+		}
 
-        // Parse BPW from quantization level if not provided
-        if bpw == 0 {
-            bpw, err = ParseBPWOrQuant(ollamaModelInfo.Details.QuantizationLevel)
-            if err != nil {
-                return 0, fmt.Errorf("error parsing BPW from Ollama quantization level: %v", err)
-            }
-        }
+		// Parse BPW from quantization level if not provided
+		if bpw == 0 {
+			bpw, err = ParseBPWOrQuant(ollamaModelInfo.Details.QuantizationLevel)
+			if err != nil {
+				return 0, fmt.Errorf("error parsing BPW from Ollama quantization level: %v", err)
+			}
+		}
 
-        logging.DebugLogger.Printf("Processed Ollama Model Config: %+v", config)
-    } else {
-        // Use Hugging Face model information
-        config, err = GetModelConfig(modelID, accessToken)
-        if err != nil {
-            return 0, err
-        }
-    }
+		logging.DebugLogger.Printf("Processed Ollama Model Config: %+v", config)
+	} else {
+		// Use Hugging Face model information
+		config, err = GetModelConfig(modelID, accessToken)
+		if err != nil {
+			return 0, err
+		}
+	}
 
-     bpwValues := GetBPWValues(bpw, kvCacheQuant)
+	bpwValues := GetBPWValues(bpw, kvCacheQuant)
 
-    if context == 0 {
-        if ollamaModelInfo != nil {
-            contextLength, found := extractModelInfo(ollamaModelInfo.ModelInfo, "context_length")
-            if found {
-                context = int(contextLength)
-            }
-        }
-        if context == 0 {
-            context = config.MaxPositionEmbeddings
-        }
-    }
-    if context == 0 {
-        context = 2048 // Default context if not provided
-    }
+	if context == 0 {
+		if ollamaModelInfo != nil {
+			contextLength, found := extractModelInfo(ollamaModelInfo.ModelInfo, "context_length")
+			if found {
+				context = int(contextLength)
+			}
+		}
+		if context == 0 {
+			context = config.MaxPositionEmbeddings
+		}
+	}
+	if context == 0 {
+		context = 2048 // Default context if not provided
+	}
 
-    vram := CalculateVRAMRaw(config, bpwValues, context, 1, true)
-    return math.Round(vram*100) / 100, nil
+	vram := CalculateVRAMRaw(config, bpwValues, context, 1, true)
+	return math.Round(vram*100) / 100, nil
 }
 
 // CalculateContext calculates the maximum context for a given memory constraint
-func CalculateContext(modelID string, memory, bpw float64, kvCacheQuant KVCacheQuantisation, accessToken string, ollamaModelInfo *OllamaModelInfo) (int, error) {
-    logging.DebugLogger.Println("Calculating context...")
+func CalculateContext(modelID string, memory, bpw float64, kvCacheQuant KVCacheQuantisation, accessToken string, ollamaModelInfo *OllamaModelInfo, topContext int) (int, error) {
+	logging.DebugLogger.Println("Calculating context...")
 
-    var maxContext int
-    if ollamaModelInfo != nil {
-        contextLength, found := extractModelInfo(ollamaModelInfo.ModelInfo, "context_length")
-        if found {
-            maxContext = int(contextLength)
-        } else {
-            // If context_length is not found, use a default value or estimate
-            maxContext = 2048 // Default value, adjust as needed
-        }
-    } else {
-        config, err := GetModelConfig(modelID, accessToken)
-        if err != nil {
-            return 0, err
-        }
-        maxContext = config.MaxPositionEmbeddings
-    }
+	var maxContext int
+	if ollamaModelInfo != nil {
+		contextLength, found := extractModelInfo(ollamaModelInfo.ModelInfo, "context_length")
+		if found {
+			maxContext = int(contextLength)
+		} else {
+			// If context_length is not found, use the provided topContext
+			maxContext = topContext
+		}
+	} else {
+		config, err := GetModelConfig(modelID, accessToken)
+		if err != nil {
+			return 0, err
+		}
+		maxContext = config.MaxPositionEmbeddings
+	}
 
-    // Rest of the function remains the same
-    minContext := 512
-    low, high := minContext, maxContext
-    for low < high {
-        mid := (low + high + 1) / 2
-        vram, err := CalculateVRAM(modelID, bpw, mid, kvCacheQuant, accessToken, ollamaModelInfo)
-        if err != nil {
-            return 0, err
-        }
-        if vram > memory {
-            high = mid - 1
-        } else {
-            low = mid
-        }
-    }
+	// Use the smaller of maxContext and topContext
+	if topContext < maxContext {
+		maxContext = topContext
+	}
 
-    context := low
-    for context <= maxContext {
-        vram, err := CalculateVRAM(modelID, bpw, context, kvCacheQuant, accessToken, ollamaModelInfo)
-        if err != nil {
-            return 0, err
-        }
-        if vram >= memory {
-            break
-        }
-        context += 100
-    }
+	minContext := 512
+	low, high := minContext, maxContext
+	for low < high {
+		mid := (low + high + 1) / 2
+		vram, err := CalculateVRAM(modelID, bpw, mid, kvCacheQuant, accessToken, ollamaModelInfo)
+		if err != nil {
+			return 0, err
+		}
+		if vram > memory {
+			high = mid - 1
+		} else {
+			low = mid
+		}
+	}
 
-    return context - 100, nil
+	context := low
+	for context <= maxContext {
+		vram, err := CalculateVRAM(modelID, bpw, context, kvCacheQuant, accessToken, ollamaModelInfo)
+		if err != nil {
+			return 0, err
+		}
+		if vram >= memory {
+			break
+		}
+		context += 100
+	}
+
+	return context - 100, nil
 }
 
 // CalculateBPW calculates the best BPW for a given memory and context constraint
@@ -687,7 +691,7 @@ func levenshteinDistance(s1, s2 string) int {
 	return d[m][n]
 }
 
-func GenerateQuantTable(modelID string, accessToken string, fitsVRAM float64, ollamaModelInfo *OllamaModelInfo) (QuantResultTable, error) {
+func GenerateQuantTable(modelID string, accessToken string, fitsVRAM float64, ollamaModelInfo *OllamaModelInfo, topContext int) (QuantResultTable, error) {
 	if fitsVRAM == 0 {
 		var err error
 		fitsVRAM, err = GetAvailableMemory()
@@ -699,7 +703,9 @@ func GenerateQuantTable(modelID string, accessToken string, fitsVRAM float64, ol
 	}
 
 	table := QuantResultTable{ModelID: modelID, FitsVRAM: fitsVRAM}
-	contextSizes := []int{2048, 8192, 16384, 32768, 49152, 65536}
+
+	// Generate context sizes based on the topContext
+	contextSizes := generateContextSizes(topContext)
 
 	if ollamaModelInfo == nil {
 		_, err := GetModelConfig(modelID, accessToken)
@@ -744,12 +750,39 @@ func GenerateQuantTable(modelID string, accessToken string, fitsVRAM float64, ol
 	return table, nil
 }
 
+// generateContextSizes generates a slice of context sizes based on the topContext
+func generateContextSizes(topContext int) []int {
+	sizes := []int{2048, 8192}
+	current := 16384
+	for current <= topContext {
+		sizes = append(sizes, current)
+		current *= 2
+	}
+	if current/2 < topContext {
+		sizes = append(sizes, topContext)
+	}
+	return sizes
+}
+
 func PrintFormattedTable(table QuantResultTable) string {
 	var buf bytes.Buffer
 	tw := tablewriter.NewWriter(&buf)
 
+	// Get context sizes from the first result (assuming all results have the same context sizes)
+	var contextSizes []int
+	if len(table.Results) > 0 {
+		for context := range table.Results[0].Contexts {
+			contextSizes = append(contextSizes, context)
+		}
+		sort.Ints(contextSizes)
+	}
+
 	// Set table header
-	tw.SetHeader([]string{"Quant|Ctx", "BPW", "2K", "8K", "16K", "32K", "49K", "64K"})
+	header := []string{"Quant|Ctx", "BPW"}
+	for _, context := range contextSizes {
+		header = append(header, fmt.Sprintf("%dK", context/1024))
+	}
+	tw.SetHeader(header)
 
 	// Set table style
 	tw.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
@@ -758,12 +791,11 @@ func PrintFormattedTable(table QuantResultTable) string {
 	tw.SetRowSeparator("-")
 
 	// Set header colour to bright white
-	headerColours := make([]tablewriter.Colors, 8)
+	headerColours := make([]tablewriter.Colors, len(header))
 	for i := range headerColours {
 		headerColours[i] = tablewriter.Colors{tablewriter.FgHiWhiteColor}
 	}
 	tw.SetHeaderColor(headerColours...)
-	// set header row colours to bright white
 
 	// Prepare data rows
 	for _, result := range table.Results {
@@ -773,9 +805,12 @@ func PrintFormattedTable(table QuantResultTable) string {
 		}
 
 		// Add VRAM estimates for each context size
-		contextSizes := []int{2048, 8192, 16384, 32768, 49152, 65536}
 		for _, context := range contextSizes {
-			vram := result.Contexts[context]
+			vram, ok := result.Contexts[context]
+			if !ok {
+				row = append(row, "-")
+				continue
+			}
 
 			fp16Str := getColouredVRAM(vram.VRAM, fmt.Sprintf("%.1f", vram.VRAM), table.FitsVRAM)
 
@@ -786,8 +821,7 @@ func PrintFormattedTable(table QuantResultTable) string {
 				combinedStr := fmt.Sprintf("%s(%s,%s)", fp16Str, q8Str, q4Str)
 				row = append(row, combinedStr)
 			} else {
-				combinedStr := fp16Str
-				row = append(row, combinedStr)
+				row = append(row, fp16Str)
 			}
 		}
 


### PR DESCRIPTION
- fix: #117
- feat: add `--vram-to-nth` to specify context size to calculate out to