### PR TITLE
docs: "command not found: gollama"

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Download the most recent release from the [releases page](https://github.com/sam
 
 e.g. `zip -d gollama*.zip -d gollama && mv gollama /usr/local/bin`
 
+### if "command not found: gollama"
+
+If you see this error, add environment variables to `.zshrc` or `.bashrc`.
+
+```shell
+echo 'export PATH=$PATH:$HOME/go/bin' >> ~/.zshrc
+```
+
 ## Usage
 
 To run the `gollama` application, use the following command:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If you see this error, add environment variables to `.zshrc` or `.bashrc`.
 
 ```shell
 echo 'export PATH=$PATH:$HOME/go/bin' >> ~/.zshrc
+source ~/.zshrc
 ```
 
 ## Usage


### PR DESCRIPTION
### Description
- This PR adds instructions for setting environment variables to resolve the command not found: gollama error.
- Without this setup, some users might encounter issues when running the gollama command after installation.