### PR TITLE
main: add reverse linking (LM Studio -> ollama)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Inspect (`i`)
 
 Link (`l`), Link All (`L`) and Link in the reverse direction: (`link-lmstudio`)
 
-When linking models to LM Studio, Gollama creates a Modelfile with default parameters and template that you can adjust.
+When linking models to LM Studio, Gollama creates a Modelfile with the template from LM-Studio and a set of default parameters that you can adjust.
 
 Note: Linking requires admin privileges if you're running Windows.
 
@@ -152,6 +152,7 @@ Note: Linking requires admin privileges if you're running Windows.
 - `-l`: List all available Ollama models and exit
 - `-L`: Link all available Ollama models to LM Studio and exit
 - `-link-lmstudio`: Link all available LM Studio models to Ollama and exit
+- `--dry-run`: Show what would be linked without making any changes (use with -link-lmstudio or -L)
 - `-s <search term>`: Search for models by name
   - OR operator (`'term1|term2'`) returns models that match either term
   - AND operator (`'term1&term2'`) returns models that match both terms

--- a/README.md
+++ b/README.md
@@ -141,14 +141,17 @@ Inspect (`i`)
 
 #### Link
 
-Link (`l`) and Link All (`L`)
+Link (`l`), Link All (`L`) and Link in the reverse direction: (`link-lmstudio`)
 
-Note: Requires Admin privileges if you're running Windows.
+When linking models to LM Studio, Gollama creates a Modelfile with default parameters and template that you can adjust.
+
+Note: Linking requires admin privileges if you're running Windows.
 
 #### Command-line Options
 
 - `-l`: List all available Ollama models and exit
 - `-L`: Link all available Ollama models to LM Studio and exit
+- `-link-lmstudio`: Link all available LM Studio models to Ollama and exit
 - `-s <search term>`: Search for models by name
   - OR operator (`'term1|term2'`) returns models that match either term
   - AND operator (`'term1&term2'`) returns models that match both terms

--- a/app_model.go
+++ b/app_model.go
@@ -594,7 +594,7 @@ func (m *AppModel) handleLinkModelKey() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if item, ok := m.list.SelectedItem().(Model); ok {
-		message, err := linkModel(item.Name, m.lmStudioModelsDir, m.noCleanup, m.client)
+		message, err := linkModel(item.Name, m.lmStudioModelsDir, m.noCleanup, false, m.client)
 		if err != nil {
 			m.message = fmt.Sprintf("Error linking model: %v", err)
 		} else if message != "" {
@@ -615,7 +615,7 @@ func (m *AppModel) handleLinkAllModelsKey() (tea.Model, tea.Cmd) {
 	}
 	var messages []string
 	for _, model := range m.models {
-		message, err := linkModel(model.Name, m.lmStudioModelsDir, m.noCleanup, m.client)
+		message, err := linkModel(model.Name, m.lmStudioModelsDir, m.noCleanup, false, m.client)
 		if err != nil {
 			messages = append(messages, fmt.Sprintf("Error linking model %s: %v", model.Name, err))
 		} else if message != "" {

--- a/lmstudio/link.go
+++ b/lmstudio/link.go
@@ -1,0 +1,145 @@
+package lmstudio
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/sammcj/gollama/logging"
+	"github.com/sammcj/gollama/utils"
+)
+
+type Model struct {
+	Name     string
+	Path     string
+	FileType string // e.g., "gguf", "bin", etc.
+}
+
+// ScanModels scans the given directory for LM Studio model files
+func ScanModels(dirPath string) ([]Model, error) {
+	var models []Model
+
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Check for model file extensions
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext == ".gguf" || ext == ".bin" {
+			name := strings.TrimSuffix(filepath.Base(path), ext)
+			models = append(models, Model{
+				Name:     name,
+				Path:     path,
+				FileType: strings.TrimPrefix(ext, "."),
+			})
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error scanning directory: %w", err)
+	}
+
+	return models, nil
+}
+
+// GetOllamaModelDir returns the default Ollama models directory for the current OS
+func GetOllamaModelDir() string {
+	homeDir := utils.GetHomeDir()
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(homeDir, ".ollama", "models")
+	} else if runtime.GOOS == "linux" {
+		return "/usr/share/ollama/models"
+	}
+	// Add Windows path if needed
+	return filepath.Join(homeDir, ".ollama", "models")
+}
+
+// modelExists checks if a model is already registered with Ollama
+func modelExists(modelName string) bool {
+	cmd := exec.Command("ollama", "list")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(output), modelName)
+}
+
+// createModelfile creates a Modelfile for the given model
+func createModelfile(modelName string, modelPath string) error {
+	modelfilePath := filepath.Join(filepath.Dir(modelPath), fmt.Sprintf("Modelfile.%s", modelName))
+
+	// Check if Modelfile already exists
+	if _, err := os.Stat(modelfilePath); err == nil {
+		return nil
+	}
+
+	modelfileContent := fmt.Sprintf(`FROM %s
+PARAMETER temperature 0.7
+PARAMETER top_k 40
+PARAMETER top_p 0.4
+PARAMETER repeat_penalty 1.1
+PARAMETER repeat_last_n 64
+PARAMETER seed 0
+PARAMETER stop "Human:" "Assistant:"
+TEMPLATE """
+{{.Prompt}}
+Assistant: """
+SYSTEM """You are a helpful AI assistant."""
+`, filepath.Base(modelPath))
+
+	return os.WriteFile(modelfilePath, []byte(modelfileContent), 0644)
+}
+
+// LinkModelToOllama links an LM Studio model to Ollama
+func LinkModelToOllama(model Model) error {
+	ollamaDir := GetOllamaModelDir()
+
+	// Create Ollama models directory if it doesn't exist
+	if err := os.MkdirAll(ollamaDir, 0755); err != nil {
+		return fmt.Errorf("failed to create Ollama models directory: %w", err)
+	}
+
+	targetPath := filepath.Join(ollamaDir, filepath.Base(model.Path))
+
+	// Create symlink for model file
+	if err := os.Symlink(model.Path, targetPath); err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("failed to create symlink: %w", err)
+		}
+	}
+
+	// Check if model is already registered with Ollama
+	if modelExists(model.Name) {
+		return nil
+	}
+
+	// Create model-specific Modelfile
+	modelfilePath := filepath.Join(filepath.Dir(targetPath), fmt.Sprintf("Modelfile.%s", model.Name))
+	if err := createModelfile(model.Name, targetPath); err != nil {
+		return fmt.Errorf("failed to create Modelfile: %w", err)
+	}
+
+	cmd := exec.Command("ollama", "create", model.Name, "-f", modelfilePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create Ollama model: %s\n%w", string(output), err)
+	}
+
+	// Clean up the Modelfile after successful creation
+	if err := os.Remove(modelfilePath); err != nil {
+		logging.ErrorLogger.Printf("Warning: Could not remove temporary Modelfile %s: %v\n", modelfilePath, err)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -389,16 +389,24 @@ func main() {
 		}
 
 		fmt.Printf("Found %d LM Studio models\n", len(models))
+		var successCount, failCount int
 
 		for _, model := range models {
 			fmt.Printf("Linking model %s... ", model.Name)
 			if err := lmstudio.LinkModelToOllama(model); err != nil {
 				logging.ErrorLogger.Printf("Error linking model %s: %v\n", model.Name, err)
 				fmt.Printf("failed: %v\n", err)
+				failCount++
 				continue
 			}
 			logging.InfoLogger.Printf("Model %s linked successfully\n", model.Name)
 			fmt.Println("success!")
+			successCount++
+		}
+
+		fmt.Printf("\nSummary: %d models linked successfully, %d failed\n", successCount, failCount)
+		if failCount > 0 {
+			os.Exit(1)
 		}
 		os.Exit(0)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sammcj/gollama/logging"
 )
@@ -25,4 +26,9 @@ func GetConfigDir() string {
 // getConfigPath returns the path to the configuration JSON file.
 func GetConfigPath() string {
 	return filepath.Join(GetHomeDir(), ".config", "gollama", "config.json")
+}
+
+// IsLocalhost checks if a URL or host string refers to localhost
+func IsLocalhost(url string) bool {
+	return strings.Contains(url, "localhost") || strings.Contains(url, "127.0.0.1")
 }


### PR DESCRIPTION
Fixes #68

I was surprised that gollama only lets you use LLMs from ollama -> lm studio. (I started with LM Studio and just today installed ollama.)

I prompted Cursor to write the code and it seems to work. It takes awhile to import the first time (it has to generate Modelfiles) but subsequent runs are instantaneous. Installing the same model with ollama afterwards is a no-op since it has the link from LM Studio.

The only flaw I know of is when you download new models to LM Studio you will have to rerun this command.

The `type AppModel struct {` got reformatted, it's more consistent this way.

Cursor/claude-3.5-sonnet did all the coding--it's very good at `go` and easy to have it make whatever changes you need to see this PR through.

```bash
% ./gollama -link-lmstudio
Scanning for LM Studio models in: /Users/erg/.lmstudio/models
Found 20 LM Studio models
Linking model Hermes-3-Llama-3.2-3B.Q4_K_M... success!
Linking model qwen2.5-coder-14b-instruct-q4_0... success!
Linking model qwen2.5-coder-32b-instruct-q4_0... success!
Linking model qwen2.5-coder-3b-instruct-q4_0... success!
Linking model DeepSeek-R1-Distill-Qwen-14B-Q4_0... success!
Linking model DeepSeek-R1-Distill-Qwen-32B-Q4_0... success!
Linking model DeepSeek-R1-Distill-Llama-8B-Q4_K_M... success!
Linking model Llama-3.3-70B-Instruct-Q4_K_M...
success!
Linking model Llama-3.3-70B-Instruct-Q6_K-00001-of-00002... success!
Linking model Llama-3.3-70B-Instruct-Q6_K-00002-of-00002... success!
Linking model Mistral-7B-Instruct-v0.3-Q4_K_M... success!
Linking model Mistral-Small-24B-Instruct-2501-Q6_K... success!
Linking model granite-3.1-8b-instruct-Q4_K_M... success!
Linking model granite-embedding-278m-multilingual-Q4_K_M... success!
Linking model phi-4-Q4_K_M... success!
Linking model DeepSeek-R1-Distill-Llama-70B-Q4_K_M...
```
