### PR TITLE
Don't store dist paths in release archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ ci: ## build for linux and macOS
 	GOOS=linux GOARCH=amd64 go build -v -ldflags="-X 'main.Version=$(GOLLAMA_VERSION)'" -o ./dist/linux_amd64/
 	GOOS=linux GOARCH=arm64 go build -v -ldflags="-X 'main.Version=$(GOLLAMA_VERSION)'" -o ./dist/linux_arm64/
 
-	@zip -r gollama-macos.zip ./dist/macos/gollama
-	@zip -r gollama-linux-amd64.zip ./dist/linux_amd64/gollama
-	@zip -r gollama-linux-arm64.zip ./dist/linux_arm64/gollama
+	@zip -rj gollama-macos.zip ./dist/macos/gollama
+	@zip -rj gollama-linux-amd64.zip ./dist/linux_amd64/gollama
+	@zip -rj gollama-linux-arm64.zip ./dist/linux_arm64/gollama
 
 	@echo "Build completed"
 	@echo "macOS: ./dist/macos/gollama"


### PR DESCRIPTION
**TLDR**: Stores just the release file for easy extraction.

This adds the `j` flag to the `zip` command in the make file's CI step
>
>-j
>--junk-paths
>Store just the name of a saved file (junk the path), and do not store
> directory names. By default, zip will store the full path (relative to the current directory).

<https://man.archlinux.org/man/zip.1.en#:~:text=command%20line%20pattern.-,%2Dj,-%2D%2Djunk%2Dpaths>


### Before

```bash
# rm -f gollama*.zip; zip -r gollama-linux-amd64.zip ./dist/linux_amd64/gollama; unzip -l gollama-linux-amd64.zip
  adding: dist/linux_amd64/gollama (stored 0%)
Archive:  gollama-linux-amd64.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2025-03-08 12:39   dist/linux_amd64/gollama
---------                     -------
        0                     1 file

```

### After
```bash
# rm -f gollama*.zip; zip -rj gollama-linux-amd64.zip ./dist/linux_amd64/gollama; unzip -l gollama-linux-amd64.zip
  adding: gollama (stored 0%)
Archive:  gollama-linux-amd64.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2025-03-08 12:39   gollama
---------                     -------
        0                     1 file
```

The point of this is that it's fewer steps/arguments to put the binary in the right place. I can't think of a good reason for having the file in a `dist` directory.
Currently one has to either move the file out of the path and then delete it or use
```bash
unzip -j gollama-linux-amd64.zip dist/linux_amd64/gollama
```


