### PR TITLE
fix(lmstudio): include symlinked model files in ScanModels & document bidirectional sync

### DIFF
--- a/lmstudio/link.go
+++ b/lmstudio/link.go
@@ -68,11 +68,8 @@ func ScanModels(dirPath string) ([]Model, error) {
 			return walkErr
 		}
 
-		// Skip directories and symlinks
-		if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
-			if info.Mode()&os.ModeSymlink != 0 {
-				logging.DebugLogger.Printf("Skipping symlinked model: %s\n", path)
-			}
+		// Skip directories
+		if info.IsDir() {
 			return nil
 		}
 


### PR DESCRIPTION
<img width="1054" alt="image" src="https://github.com/user-attachments/assets/3416dcb7-de77-4cb4-8c8e-564d69a78e41" />

This PR does two things:

1. **Fixes** `lmstudio.ScanModels` so that `.gguf` and `.bin` symlinks (how LM Studio stores its community models) are no longer skipped during the directory walk.  
2. **Updates documentation** to fully describe both one-way and reverse sync flows, plus the new `-ollama-dir` / `-lm-dir` flags:

   - `-L` now clearly marked as “one-way sync” (Ollama → LM Studio).
   - `-link-lmstudio` documented as “reverse sync” (LM Studio → Ollama).
   - Added examples for overriding the default directories at runtime.

---

### What

- **ScanModels**  
  - Removed the `info.Mode()&os.ModeSymlink != 0` check so that GGUF/BIN symlinks are picked up.
  - Only actual directories are skipped now; all valid model files (including symlinks) are returned.

- **Docs / README**  
  - Clarified CLI flags:
    - `-L`: Link all Ollama models → LM Studio (one-way sync)  
    - `-link-lmstudio`: Link all LM Studio models → Ollama (reverse sync)  
    - `-ollama-dir <path>` / `-lm-dir <path>`: override default model directories  
  - Added shell snippets illustrating custom directory usage.

---

### Why

LM Studio installs its community and cache models as symlinks under `~/.cache/lm-studio/models`. By filtering out all symlinks, Gollama could never discover those files, so “Link All” did nothing. This change restores the expected behavior, and the updated docs make it clear how to run both sync directions and override paths.

---

### How to Test it

1. **Before** this branch:
   ```bash
   gollama -L               # no community models should appear
   gollama -link-lmstudio   # no reverse-sync models should appear
   ```

2. **Switch to this branch & rebuild**:
   ```bash
   go build ./...
   ```

3. **After** the change:
   ```bash
   ./gollama -L             # you should see & link every `.gguf/.bin` symlink under ~/.cache/lm-studio/models
   ./gollama -link-lmstudio # you should see & link every local LM Studio model back into Ollama
   ```

4. Test custom directories:
   ```bash
   ./gollama --ollama-dir ~/my/ollama/models -l
   ./gollama -L --lm-dir ~/other/lmstudio/models
   ```

5. Optionally, fire up the TUI and confirm all community models show up correctly.

- [x] Code change follows existing style & patterns  
- [x] Manual testing of one-way & reverse sync flows  
- [x] README updated with new flags & examples  
- [ ] (opt) Unit tests added — n/a for filesystem walk  

