### PR TITLE
feat(linking): use canonical model name when linking to lm-studio

### DIFF
--- a/operations.go
+++ b/operations.go
@@ -1065,9 +1065,12 @@ func linkModel(modelName, lmStudioModelsDir string, noCleanup bool, dryRun bool,
 	}
 
 	// Create a clean model name for the file
-	lmStudioModelName := strings.ReplaceAll(strings.ReplaceAll(modelName, ":", "-"), "_", "-")
-	lmStudioModelName = strings.ReplaceAll(lmStudioModelName, "/", "-")
-	lmStudioModelDir := filepath.Join(lmStudioModelsDir, author, lmStudioModelName+"-GGUF")
+	// * model tag is appended to the model name if it's not the default `latest` tag
+	lmStudioModelName := fullModelName.Model
+	if fullModelName.Tag != ollama_model.DefaultName().Tag {
+		lmStudioModelName += "-" + fullModelName.Tag
+	}
+	lmStudioModelDir := filepath.Join(lmStudioModelsDir, author, lmStudioModelName)
 
 	// Check if the main model path is a valid file
 	fileInfo, err := os.Stat(modelFiles.MainModel)


### PR DESCRIPTION
In this PR, `github.com/ollama/ollama/types/model` package is introduced to parse the model name as canonically structured name, and render a more readable LM Studio model name accordingly.

Before:
<img width="3738" height="794" alt="image" src="https://github.com/user-attachments/assets/40e12a20-6068-4f9f-80b3-6fed08e27120" />

After:
<img width="3736" height="794" alt="image" src="https://github.com/user-attachments/assets/c40b1379-6762-40c5-bcd3-73fbb15ba4f4" />

Ollama models:
```
> ollama list
NAME                                                                 ID              SIZE      MODIFIED
gpt-oss:20b                                                          832b19e6226e    11 GB     3 hours ago
gpt-oss:120b                                                         bf160ed3ed16    65 GB     3 hours ago
modelscope.cn/unsloth/GLM-4.5-Air-GGUF:latest                        16418c4f65ca    45 GB     3 days ago
modelscope.cn/unsloth/Qwen3-Coder-30B-A3B-Instruct-1M-GGUF:latest    e906ba9691c3    18 GB     3 days ago
modelscope.cn/Qwen/Qwen3-32B-GGUF:latest                             8d16791f371f    19 GB     2 weeks ago
SakuraLLM/Sakura-7B-Qwen2.5-v1.0:latest                              d0a0c0c4d518    4.3 GB    5 months ago
SakuraLLM/Sakura-14B-Qwen2.5-v1.0:latest                             00f7d9fb19cd    8.2 GB    5 months ago
```